### PR TITLE
Remove bashisms from script and correct library detection

### DIFF
--- a/ksm-wrapper
+++ b/ksm-wrapper
@@ -22,9 +22,9 @@ readonly KSM_PATH=$(cd $(dirname $0) ; pwd)
 readonly KSM_SO_GIT="${KSM_PATH}/libksm_preload.so"
 readonly KSM_SO_CMAKE="${KSM_PATH}/../share/ksm_preload/libksm_preload.so"
 
-if  [[ -x "${KSM_SO_GIT}" ]]; then
+if  [ -x "${KSM_SO_GIT}" ]; then
     readonly KSM_SO="${KSM_SO_GIT}"
-elif [[ -x "${KSM_SO_CMAKE}" ]]; then
+elif [ -s "${KSM_SO_CMAKE}" ]; then
     readonly KSM_SO="${KSM_SO_CMAKE}"
 else
     echo $KSM_SO_CMAKE


### PR DESCRIPTION
[[ ]] are bashisms and the same can be achieved with [ ]
-x will fail as libksm_preload.so is not installed with executable permissions.

Closes #6 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unbrice/ksm_preload/9)
<!-- Reviewable:end -->
